### PR TITLE
fix(ui): Update from `Pause` to `Play` after audio ended

### DIFF
--- a/src/routes/audio/+page.svelte
+++ b/src/routes/audio/+page.svelte
@@ -66,6 +66,8 @@
             (audioDurationText.textContent = getDuration(audioElement.duration)); // Correction if (NaN)
 
         audioElement.addEventListener('timeupdate', updateCurrentTime);
+
+        audioElement.onended = stopSong;
     });
 </script>
 


### PR DESCRIPTION
## Changes
- Add a onended function to audio element.

Fixed #2 